### PR TITLE
fix: 英語文の分割ロジックを修正

### DIFF
--- a/backend/app/services/chunker.py
+++ b/backend/app/services/chunker.py
@@ -89,5 +89,5 @@ def _split_sentences(text: str) -> list[str]:
     """日本語・英語の文を分割する"""
     import re
     # 。！？!? や改行で分割（区切り文字は保持）
-    parts = re.split(r'(?<=[。！？!?\n])', text)
+    parts = re.split(r'(?<=[。.！？!?\n])', text)
     return [p for p in parts if p.strip()]


### PR DESCRIPTION
## 概要
- `_split_sentences` の正規表現にピリオド(`.`)を追加
- 英語の文末ピリオドで正しく文分割されるように修正
- CIテスト `test_split_english_sentences` の失敗を解消