### PR TITLE
fix: セキュリティ脆弱性のあるパッケージを更新

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
-fastapi==0.115.6
+fastapi==0.122.0
 uvicorn[standard]==0.34.0
-python-multipart==0.0.20
+python-multipart==0.0.22
 openai==1.58.1
 chromadb==0.5.23
 python-dotenv==1.0.1


### PR DESCRIPTION
## 変更概要
- `python-multipart` 0.0.20 → 0.0.22（GHSA-wp53-j4wj-2cfg: パストラバーサル脆弱性修正）
- `FastAPI` 0.115.6 → 0.122.0（starlette 0.49.1+を許容するため）
  - starlette 0.49.1+ で GHSA-2c2j-9gv5-cj73, GHSA-7f5h-v6xp-fcq8 を修正