### PR TITLE
fix: split oversized sentences at character boundaries in chunk_text

### DIFF
--- a/backend/app/services/chunker.py
+++ b/backend/app/services/chunker.py
@@ -69,7 +69,7 @@ def chunk_text(
                     temp = temp[-overlap:] + sentence if overlap > 0 else sentence
                 else:
                     temp += sentence
-                # A single sentence may exceed chunk_size; flush at character boundaries
+                # 1文だけでchunk_sizeを超える場合は文字境界で強制分割
                 while len(temp) > chunk_size:
                     chunks.append(temp[:chunk_size].strip())
                     temp = temp[chunk_size - overlap:] if overlap > 0 else temp[chunk_size:]

--- a/backend/app/services/chunker.py
+++ b/backend/app/services/chunker.py
@@ -69,6 +69,10 @@ def chunk_text(
                     temp = temp[-overlap:] + sentence if overlap > 0 else sentence
                 else:
                     temp += sentence
+                # A single sentence may exceed chunk_size; flush at character boundaries
+                while len(temp) > chunk_size:
+                    chunks.append(temp[:chunk_size].strip())
+                    temp = temp[chunk_size - overlap:] if overlap > 0 else temp[chunk_size:]
             if temp.strip():
                 chunks.append(temp.strip())
         elif len(current_chunk) + len(para) + 1 > chunk_size:


### PR DESCRIPTION
## Root Cause

Two tests were failing:
- `test_custom_chunk_size`: `"a" * 1000` with `chunk_size=100` returned 1 chunk instead of 10
- `test_env_var_chunk_size`: `"あ" * 500` with `CHUNK_SIZE=100` returned 1 chunk instead of 5

In `chunk_text()`, the sentence-splitting loop had:
```python
if len(temp) + len(sentence) > chunk_size and temp:
    ...
else:
    temp += sentence
```
The `and temp` guard meant that when `temp` was empty and a single sentence exceeded `chunk_size`, it was added wholesale to `temp` without any splitting. No further splitting ever occurred for that sentence.

## Fix

Added a `while len(temp) > chunk_size` loop after each sentence append to force character-boundary splits when a sentence alone exceeds `chunk_size`:

```python
while len(temp) > chunk_size:
    chunks.append(temp[:chunk_size].strip())
    temp = temp[chunk_size - overlap:] if overlap > 0 else temp[chunk_size:]
```

## Verification

All 25 tests now pass locally.