### PR TITLE
docs: README の技術スタックを ChromaDB → PostgreSQL + pgvector に修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 ```
 [ブラウザ] → [Next.js (port 3000)] → [FastAPI (port 8000)] → [OpenAI API]
                                             ↓
-                                     [ChromaDB (組み込み)]
+                                  [PostgreSQL 16 + pgvector]
 ```
 
 ## 技術スタック
@@ -33,9 +33,10 @@
 | レイヤー | 技術 |
 |---------|------|
 | フロントエンド | Next.js 15, React 19, Tailwind CSS 4 |
-| バックエンド | Python, FastAPI |
-| ベクトルDB | ChromaDB (PersistentClient) |
+| バックエンド | Python 3.11, FastAPI |
+| ベクトルDB | PostgreSQL 16 + pgvector（psycopg2 経由） |
 | LLM / Embedding | OpenAI API (gpt-4o-mini / text-embedding-3-small) |
+| コンテナ | Docker Compose |
 
 ## 画面一覧
 
@@ -58,7 +59,7 @@ rag-support-assist/
 │   │   └── services/
 │   │       ├── chunker.py       # テキストチャンク化
 │   │       ├── embeddings.py    # Embedding生成
-│   │       ├── vectorstore.py   # ChromaDB操作
+│   │       ├── vectorstore.py   # PostgreSQL/pgvector操作
 │   │       └── rag.py           # RAG回答生成
 │   ├── requirements.txt
 │   └── .env.example
@@ -108,9 +109,33 @@ GET    /api/health             # ヘルスチェック
 
 - Python 3.11+
 - Node.js 18+
+- Docker & Docker Compose（PostgreSQL/pgvector の起動に使用）
 - OpenAI APIキー
 
-### 1. バックエンド起動
+### 1. Docker Compose で全サービスを起動（推奨）
+
+```bash
+# リポジトリルートで実行
+cp .env.example .env 2>/dev/null || true
+# .env を編集して OPENAI_API_KEY を設定
+
+docker compose up --build
+```
+
+アクセス先:
+- フロントエンド: http://localhost:3000
+- バックエンド API: http://localhost:8000
+
+### 2. 個別起動（開発時）
+
+#### 2-1. PostgreSQL + pgvector を起動
+
+```bash
+# PostgreSQL コンテナのみ起動
+docker compose up postgres -d
+```
+
+#### 2-2. バックエンド起動
 
 ```bash
 cd backend
@@ -124,13 +149,15 @@ pip install -r requirements.txt
 
 # 環境変数設定
 cp .env.example .env
-# .env を編集して OPENAI_API_KEY を設定
+# .env を編集して以下を設定:
+#   OPENAI_API_KEY=sk-...
+#   DATABASE_URL=postgres://user:password@localhost:5432/rag_support?sslmode=disable
 
-# サーバー起動
+# サーバー起動（起動時に DB マイグレーションが自動実行されます）
 uvicorn app.main:app --reload --port 8000
 ```
 
-### 2. フロントエンド起動
+#### 2-3. フロントエンド起動
 
 ```bash
 cd frontend


### PR DESCRIPTION
## 変更概要

- `README.md` のシステム構成図・技術スタック表を実際のコード（PostgreSQL + pgvector）に合わせて修正
- Docker Compose を使ったセットアップ手順を整備
- 個別起動手順に `DATABASE_URL` 環境変数の設定例を追記

## 変更詳細

### 誤記修正

| 項目 | 修正前 | 修正後 |
|------|--------|--------|
| システム構成図のDB | `ChromaDB (組み込み)` | `PostgreSQL 16 + pgvector` |
| 技術スタックのベクトルDB | `ChromaDB (PersistentClient)` | `PostgreSQL 16 + pgvector（psycopg2 経由）` |
| ディレクトリ構成のコメント | `# ChromaDB操作` | `# PostgreSQL/pgvector操作` |

### 追加・拡充

- **Docker Compose 一括起動手順**（推奨）を最上位に追加
- 個別起動手順を「2-1/2-2/2-3」に整理
- `DATABASE_URL` の設定例を `.env` 編集手順内に追記
- バックエンド起動時の DB マイグレーション自動実行について注記
- 前提条件に「Docker & Docker Compose」を追加

## 背景

実装は `psycopg2` + pgvector（PostgreSQL 拡張）を使用しているが、README には `ChromaDB` と記載されており、  
新規参加者がセットアップ時に混乱する原因となっていた（Fixes #19）。

## 対応 Issue

Closes #19

## 動作確認手順

```bash
# README の markdown を確認
cat README.md | grep -A5 "システム構成"
cat README.md | grep -A10 "技術スタック"
```
