### PR TITLE
test: queryルーターおよびdocumentsルーターのユニットテスト追加

### DIFF
--- a/backend/tests/test_documents_router.py
+++ b/backend/tests/test_documents_router.py
@@ -1,0 +1,160 @@
+"""documents ルーターのユニットテスト"""
+import io
+import sys
+from unittest.mock import MagicMock, patch
+
+# 外部依存を事前にモック化
+sys.modules.setdefault("psycopg2", MagicMock())
+sys.modules.setdefault("openai", MagicMock())
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+_FIXED_TS = "2026-06-27T00:00:00+00:00"
+
+
+@pytest.fixture
+def client():
+    """lifespan の migrate() をモックしてテストクライアントを返す"""
+    with patch("app.main.migrate"), patch("app.main.get_chunk_count", return_value=0):
+        with TestClient(app) as c:
+            yield c
+
+
+def _upload(client, content: bytes, filename: str = "test.txt", category: str = "faq"):
+    """ファイルアップロードのヘルパー"""
+    return client.post(
+        "/api/documents/upload",
+        files={"file": (filename, io.BytesIO(content), "text/plain")},
+        data={"category": category},
+    )
+
+
+class TestUploadDocument:
+    def test_正常系_txtファイルアップロード(self, client):
+        with patch("app.routers.documents.chunk_text", return_value=["チャンク1", "チャンク2"]), \
+             patch("app.routers.documents.add_documents", return_value=2):
+            resp = _upload(client, b"FAQ content for testing", "faq.txt", "faq")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["name"] == "faq.txt"
+        assert body["category"] == "faq"
+        assert body["chunk_count"] == 2
+        assert "id" in body
+        assert "uploaded_at" in body
+
+    def test_正常系_mdファイルアップロード(self, client):
+        with patch("app.routers.documents.chunk_text", return_value=["c1"]), \
+             patch("app.routers.documents.add_documents", return_value=1):
+            resp = _upload(client, b"# Markdown content", "readme.md", "manual")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "readme.md"
+        assert resp.json()["category"] == "manual"
+
+    def test_正常系_csvファイルアップロード(self, client):
+        with patch("app.routers.documents.chunk_text", return_value=["c1"]), \
+             patch("app.routers.documents.add_documents", return_value=1):
+            resp = _upload(client, b"col1,col2\nv1,v2", "data.csv", "history")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "data.csv"
+
+    def test_正常系_全カテゴリ(self, client):
+        for cat in ["faq", "terms", "manual", "history"]:
+            with patch("app.routers.documents.chunk_text", return_value=["c"]), \
+                 patch("app.routers.documents.add_documents", return_value=1):
+                resp = _upload(client, b"content", "file.txt", cat)
+            assert resp.status_code == 200, f"category={cat} が失敗"
+
+    def test_400_対応外拡張子(self, client):
+        resp = _upload(client, b"content", "file.pdf", "faq")
+        assert resp.status_code == 400
+        assert "対応形式" in resp.json()["detail"]
+
+    def test_400_対応外拡張子_docx(self, client):
+        resp = _upload(client, b"content", "file.docx", "faq")
+        assert resp.status_code == 400
+
+    def test_400_無効カテゴリ(self, client):
+        resp = _upload(client, b"content", "file.txt", "invalid_cat")
+        assert resp.status_code == 400
+        assert "カテゴリ" in resp.json()["detail"]
+
+    def test_400_空ファイル(self, client):
+        resp = _upload(client, b"", "empty.txt", "faq")
+        assert resp.status_code == 400
+        assert "空" in resp.json()["detail"]
+
+    def test_400_空白のみファイル(self, client):
+        resp = _upload(client, b"   \n\n  ", "whitespace.txt", "faq")
+        assert resp.status_code == 400
+
+    def test_413_ファイルサイズ超過(self, client):
+        big_content = b"a" * (1 * 1024 * 1024 + 1)
+        with patch("app.routers.documents._MAX_UPLOAD_SIZE_BYTES", 1 * 1024 * 1024), \
+             patch("app.routers.documents._MAX_UPLOAD_SIZE_MB", 1):
+            resp = _upload(client, big_content, "big.txt", "faq")
+        assert resp.status_code == 413
+        assert "上限" in resp.json()["detail"]
+
+    def test_400_拡張子なしファイル名(self, client):
+        resp = _upload(client, b"content", "noext", "faq")
+        assert resp.status_code == 400
+
+
+class TestListDocuments:
+    def test_正常系_空一覧(self, client):
+        with patch("app.routers.documents.get_document_stats", return_value=[]):
+            resp = client.get("/api/documents")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["documents"] == []
+        assert body["total"] == 0
+
+    def test_正常系_1件(self, client):
+        stats = [
+            {"id": "id1", "name": "a.txt", "category": "faq", "chunk_count": 3, "uploaded_at": _FIXED_TS},
+        ]
+        with patch("app.routers.documents.get_document_stats", return_value=stats):
+            resp = client.get("/api/documents")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["documents"][0]["name"] == "a.txt"
+
+    def test_正常系_複数件(self, client):
+        stats = [
+            {"id": "id1", "name": "a.txt", "category": "faq", "chunk_count": 3, "uploaded_at": _FIXED_TS},
+            {"id": "id2", "name": "b.md", "category": "manual", "chunk_count": 5, "uploaded_at": _FIXED_TS},
+            {"id": "id3", "name": "c.csv", "category": "terms", "chunk_count": 2, "uploaded_at": _FIXED_TS},
+        ]
+        with patch("app.routers.documents.get_document_stats", return_value=stats):
+            resp = client.get("/api/documents")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 3
+        assert len(body["documents"]) == 3
+        assert body["documents"][1]["chunk_count"] == 5
+
+
+class TestDeleteDocument:
+    def test_正常系_削除成功(self, client):
+        with patch("app.routers.documents.delete_document", return_value=3):
+            resp = client.delete("/api/documents/test-doc-id")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["deleted_chunks"] == 3
+        assert body["document_id"] == "test-doc-id"
+
+    def test_正常系_1チャンク削除(self, client):
+        with patch("app.routers.documents.delete_document", return_value=1):
+            resp = client.delete("/api/documents/some-id")
+        assert resp.status_code == 200
+        assert resp.json()["deleted_chunks"] == 1
+
+    def test_404_存在しないドキュメント(self, client):
+        with patch("app.routers.documents.delete_document", return_value=0):
+            resp = client.delete("/api/documents/not-exist")
+        assert resp.status_code == 404
+        assert "見つかりません" in resp.json()["detail"]

--- a/backend/tests/test_query_router.py
+++ b/backend/tests/test_query_router.py
@@ -1,0 +1,161 @@
+"""query ルーターのユニットテスト"""
+import sys
+from unittest.mock import MagicMock, patch
+
+# 外部依存を事前にモック化（他テストより先に実行される場合に備えて）
+sys.modules.setdefault("psycopg2", MagicMock())
+_openai_mod = MagicMock()
+sys.modules.setdefault("openai", _openai_mod)
+_openai_mod.OpenAI = MagicMock
+
+
+class _FakeOpenAIError(Exception):
+    """OpenAIError の代替。openai がモックされているため独自定義する。"""
+
+
+_openai_mod.OpenAIError = _FakeOpenAIError
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture
+def client():
+    """lifespan の migrate() をモックしてテストクライアントを返す"""
+    with patch("app.main.migrate"):
+        with TestClient(app) as c:
+            yield c
+
+
+def _make_search_result(docs=None, metas=None, dists=None):
+    """ベクトル検索のダミー結果を生成する"""
+    docs = docs or ["FAQ内容: 返品は購入後30日以内に可能です。"]
+    metas = metas or [{"document_name": "faq.txt", "category": "faq"}]
+    dists = dists or [0.1]
+    return {"documents": [docs], "metadatas": [metas], "distances": [dists]}
+
+
+class TestPostQuery:
+    def test_正常系_標準トーンで回答を返す(self, client):
+        with patch("app.routers.query.search", return_value=_make_search_result()), \
+             patch("app.routers.query.generate_answer", return_value=("テスト回答", False, None)):
+            resp = client.post("/api/query", json={"query": "返品方法を教えてください"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["answer"] == "テスト回答"
+        assert body["should_escalate"] is False
+        assert body["escalation_reason"] is None
+        assert len(body["sources"]) == 1
+        assert body["sources"][0]["document_name"] == "faq.txt"
+
+    def test_正常系_丁寧トーン(self, client):
+        with patch("app.routers.query.search", return_value=_make_search_result()), \
+             patch("app.routers.query.generate_answer", return_value=("丁寧な回答文", False, None)):
+            resp = client.post("/api/query", json={"query": "問い合わせ内容", "tone": "polite"})
+        assert resp.status_code == 200
+
+    def test_正常系_簡潔トーン(self, client):
+        with patch("app.routers.query.search", return_value=_make_search_result()), \
+             patch("app.routers.query.generate_answer", return_value=("簡潔な回答", False, None)):
+            resp = client.post("/api/query", json={"query": "問い合わせ", "tone": "concise"})
+        assert resp.status_code == 200
+
+    def test_正常系_エスカレーション要(self, client):
+        with patch("app.routers.query.search", return_value=_make_search_result()), \
+             patch("app.routers.query.generate_answer", return_value=("回答", True, "法的判断が必要")):
+            resp = client.post("/api/query", json={"query": "複雑な問い合わせ"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["should_escalate"] is True
+        assert body["escalation_reason"] == "法的判断が必要"
+
+    def test_正常系_relevance_score計算(self, client):
+        """distance=0.3 → relevance_score=0.7 になること"""
+        result = _make_search_result(dists=[0.3])
+        with patch("app.routers.query.search", return_value=result), \
+             patch("app.routers.query.generate_answer", return_value=("回答", False, None)):
+            resp = client.post("/api/query", json={"query": "テスト"})
+        assert resp.status_code == 200
+        assert resp.json()["sources"][0]["relevance_score"] == pytest.approx(0.7)
+
+    def test_正常系_distance1以上はscore0になる(self, client):
+        """distance >= 1 のとき relevance_score は 0.0 になること"""
+        result = _make_search_result(dists=[1.5])
+        with patch("app.routers.query.search", return_value=result), \
+             patch("app.routers.query.generate_answer", return_value=("回答", False, None)):
+            resp = client.post("/api/query", json={"query": "テスト"})
+        assert resp.status_code == 200
+        assert resp.json()["sources"][0]["relevance_score"] == 0.0
+
+    def test_正常系_複数ソース(self, client):
+        docs = ["内容1", "内容2", "内容3"]
+        metas = [
+            {"document_name": "a.txt", "category": "faq"},
+            {"document_name": "b.txt", "category": "manual"},
+            {"document_name": "c.txt", "category": "terms"},
+        ]
+        dists = [0.1, 0.2, 0.3]
+        result = _make_search_result(docs=docs, metas=metas, dists=dists)
+        with patch("app.routers.query.search", return_value=result), \
+             patch("app.routers.query.generate_answer", return_value=("回答", False, None)):
+            resp = client.post("/api/query", json={"query": "テスト"})
+        assert resp.status_code == 200
+        assert len(resp.json()["sources"]) == 3
+
+    def test_422_空クエリ(self, client):
+        resp = client.post("/api/query", json={"query": ""})
+        assert resp.status_code == 422
+
+    def test_422_空白のみクエリ(self, client):
+        resp = client.post("/api/query", json={"query": "   "})
+        assert resp.status_code == 422
+
+    def test_422_5001文字超クエリ(self, client):
+        resp = client.post("/api/query", json={"query": "あ" * 5001})
+        assert resp.status_code == 422
+
+    def test_422_無効トーン(self, client):
+        resp = client.post("/api/query", json={"query": "問い合わせ", "tone": "angry"})
+        assert resp.status_code == 422
+
+    def test_503_ベクトルDB接続エラー(self, client):
+        with patch("app.routers.query.search", side_effect=Exception("pgvector接続失敗")):
+            resp = client.post("/api/query", json={"query": "問い合わせ"})
+        assert resp.status_code == 503
+        assert "再試行" in resp.json()["detail"]
+
+    def test_503_OpenAI_APIエラー(self, client):
+        """OpenAIError をモックの例外でシミュレートする"""
+        with patch("app.routers.query.OpenAIError", _FakeOpenAIError), \
+             patch("app.routers.query.search", return_value=_make_search_result()), \
+             patch("app.routers.query.generate_answer", side_effect=_FakeOpenAIError("rate limit")):
+            resp = client.post("/api/query", json={"query": "問い合わせ"})
+        assert resp.status_code == 503
+
+    def test_500_予期しないエラー(self, client):
+        with patch("app.routers.query.OpenAIError", _FakeOpenAIError), \
+             patch("app.routers.query.search", return_value=_make_search_result()), \
+             patch("app.routers.query.generate_answer", side_effect=ValueError("unexpected")):
+            resp = client.post("/api/query", json={"query": "問い合わせ"})
+        assert resp.status_code == 500
+
+
+class TestGetHealth:
+    def test_正常系_DB接続OK(self, client):
+        with patch("app.main.get_chunk_count", return_value=42):
+            resp = client.get("/api/health")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ok"
+        assert body["vector_db"] == "connected"
+        assert body["document_chunks"] == 42
+
+    def test_DB異常_degradedを返す(self, client):
+        with patch("app.main.get_chunk_count", side_effect=Exception("DB接続失敗")):
+            resp = client.get("/api/health")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "degraded"
+        assert body["vector_db"] == "disconnected"


### PR DESCRIPTION
## 概要\n\n- `backend/tests/test_query_router.py` を新規追加（16テスト）\n- `backend/tests/test_documents_router.py` を新規追加（17テスト）\n- FastAPI `TestClient` + `unittest.mock.patch` でルーターエンドポイントを直接テスト\n- 外部依存（`psycopg2`, `openai`）は `sys.modules.setdefault()` でモック化\n\n## 変更の詳細\n\n### `test_query_router.py`\n- `POST /api/query`: 正常系（標準/丁寧/簡潔トーン、エスカレーション、relevance_score計算、複数ソース）、バリデーションエラー（空/空白/5001文字超クエリ、無効トーン）、503/500エラーハンドリング\n- `GET /api/health`: DB接続正常系・異常系\n\n### `test_documents_router.py`\n- `POST /api/documents/upload`: txt/md/csv 正常系、全カテゴリ、拡張子エラー、無効カテゴリ、空ファイル、ファイルサイズ超過（413）\n- `GET /api/documents`: 空一覧、1件、複数件\n- `DELETE /api/documents/{id}`: 削除成功、404\n\nCloses #17

---
_Generated by [Claude Code](https://claude.ai/code/session_01SqvgPUUQfVYYb4YJvmcv11)_