### PR TITLE
test: embeddings.py と vectorstore.py のユニットテスト追加

### DIFF
--- a/backend/tests/test_embeddings.py
+++ b/backend/tests/test_embeddings.py
@@ -1,0 +1,102 @@
+"""embeddings.py のユニットテスト"""
+import sys
+from unittest.mock import MagicMock, patch
+
+# 外部依存を事前にモック化（他テストより先に実行される場合に備えて）
+sys.modules.setdefault("psycopg2", MagicMock())
+_openai_mod = MagicMock()
+sys.modules.setdefault("openai", _openai_mod)
+_openai_mod.OpenAI = MagicMock
+
+import pytest  # noqa: E402
+
+import app.services.embeddings as embeddings_module  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def reset_client_singleton():
+    """テスト間で _client のシングルトン状態が漏れないようにリセットする"""
+    embeddings_module._client = None
+    yield
+    embeddings_module._client = None
+
+
+class TestGetClient:
+    def test_returns_singleton_instance(self):
+        """2回呼び出しても同一インスタンスが返ること"""
+        with patch.object(embeddings_module, "OpenAI") as mock_openai_cls:
+            mock_openai_cls.return_value = MagicMock()
+
+            client1 = embeddings_module.get_client()
+            client2 = embeddings_module.get_client()
+
+        assert client1 is client2
+        mock_openai_cls.assert_called_once()
+
+    def test_creates_instance_only_once(self):
+        """OpenAI() のコンストラクタが1回しか呼ばれないこと"""
+        with patch.object(embeddings_module, "OpenAI") as mock_openai_cls:
+            mock_openai_cls.return_value = MagicMock()
+            embeddings_module.get_client()
+            embeddings_module.get_client()
+        mock_openai_cls.assert_called_once_with()
+
+
+def _make_embedding_response(vectors):
+    """OpenAI embeddings.create() のレスポンスを模したモックを生成する"""
+    response = MagicMock()
+    response.data = [MagicMock(embedding=v) for v in vectors]
+    response.usage.total_tokens = 42
+    return response
+
+
+class TestGenerateEmbeddings:
+    def test_calls_api_with_correct_model_and_input(self):
+        """text-embedding-3-small モデルと入力テキストでAPIが呼ばれること"""
+        fake_client = MagicMock()
+        fake_client.embeddings.create.return_value = _make_embedding_response(
+            [[0.1, 0.2], [0.3, 0.4]]
+        )
+
+        with patch.object(embeddings_module, "get_client", return_value=fake_client):
+            result = embeddings_module.generate_embeddings(["テキスト1", "テキスト2"])
+
+        fake_client.embeddings.create.assert_called_once_with(
+            model="text-embedding-3-small",
+            input=["テキスト1", "テキスト2"],
+        )
+        assert result == [[0.1, 0.2], [0.3, 0.4]]
+
+    def test_returns_empty_list_for_empty_input(self):
+        """空リストを渡した場合は空リストが返ること"""
+        fake_client = MagicMock()
+        fake_client.embeddings.create.return_value = _make_embedding_response([])
+
+        with patch.object(embeddings_module, "get_client", return_value=fake_client):
+            result = embeddings_module.generate_embeddings([])
+
+        assert result == []
+
+    def test_preserves_order_of_returned_embeddings(self):
+        """レスポンスの順序通りに embedding が並ぶこと"""
+        fake_client = MagicMock()
+        fake_client.embeddings.create.return_value = _make_embedding_response(
+            [[1.0], [2.0], [3.0]]
+        )
+
+        with patch.object(embeddings_module, "get_client", return_value=fake_client):
+            result = embeddings_module.generate_embeddings(["a", "b", "c"])
+
+        assert result == [[1.0], [2.0], [3.0]]
+
+
+class TestGenerateEmbedding:
+    def test_returns_first_embedding_from_generate_embeddings(self):
+        """generate_embeddings() を単一要素リストで呼び出し、先頭要素を返すこと"""
+        with patch.object(
+            embeddings_module, "generate_embeddings", return_value=[[9.9, 8.8]]
+        ) as mock_generate:
+            result = embeddings_module.generate_embedding("単一テキスト")
+
+        mock_generate.assert_called_once_with(["単一テキスト"])
+        assert result == [9.9, 8.8]

--- a/backend/tests/test_vectorstore.py
+++ b/backend/tests/test_vectorstore.py
@@ -1,0 +1,202 @@
+"""vectorstore.py のユニットテスト"""
+import sys
+from unittest.mock import MagicMock, patch
+
+# 外部依存を事前にモック化（他テストより先に実行される場合に備えて）
+sys.modules.setdefault("psycopg2", MagicMock())
+_openai_mod = MagicMock()
+sys.modules.setdefault("openai", _openai_mod)
+_openai_mod.OpenAI = MagicMock
+
+import pytest  # noqa: E402
+
+import app.services.vectorstore as vectorstore_module  # noqa: E402
+
+
+def _make_mock_connection():
+    """psycopg2.connect() の戻り値を模したモック接続/カーソルを生成する"""
+    mock_cursor = MagicMock()
+    mock_cursor_cm = MagicMock()
+    mock_cursor_cm.__enter__.return_value = mock_cursor
+    mock_cursor_cm.__exit__.return_value = False
+
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value = mock_cursor_cm
+    return mock_conn, mock_cursor
+
+
+@pytest.fixture
+def mock_db(monkeypatch):
+    """DATABASE_URL と psycopg2.connect をモック化する"""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test:test@localhost/test")
+    mock_conn, mock_cursor = _make_mock_connection()
+    with patch.object(
+        vectorstore_module.psycopg2, "connect", return_value=mock_conn
+    ) as mock_connect:
+        yield mock_conn, mock_cursor, mock_connect
+
+
+class TestGetDatabaseUrl:
+    def test_raises_when_not_set(self, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        with pytest.raises(RuntimeError):
+            vectorstore_module._get_database_url()
+
+    def test_returns_value_when_set(self, monkeypatch):
+        monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@host/db")
+        assert vectorstore_module._get_database_url() == "postgresql://u:p@host/db"
+
+
+class TestAddDocuments:
+    def test_empty_chunks_returns_zero_without_db_access(self, mock_db):
+        """空チャンクリストの場合はDB接続もEmbedding生成も行わないこと"""
+        _, _, mock_connect = mock_db
+        result = vectorstore_module.add_documents(
+            doc_id="doc-1", chunks=[], document_name="empty.txt", category="faq"
+        )
+        assert result == 0
+        mock_connect.assert_not_called()
+
+    def test_inserts_document_and_chunks(self, mock_db):
+        """通常系: documents への1件とchunk件数分のINSERTが行われること"""
+        _, mock_cursor, _ = mock_db
+        with patch.object(
+            vectorstore_module,
+            "generate_embeddings",
+            return_value=[[0.1] * 1536, [0.2] * 1536],
+        ) as mock_gen:
+            result = vectorstore_module.add_documents(
+                doc_id="doc-1",
+                chunks=["チャンク1", "チャンク2"],
+                document_name="faq.txt",
+                category="faq",
+            )
+
+        assert result == 2
+        mock_gen.assert_called_once_with(["チャンク1", "チャンク2"])
+        # documents テーブルへのINSERT 1回 + chunk INSERT 2回 = 計3回execute
+        assert mock_cursor.execute.call_count == 3
+
+
+class TestSearch:
+    def test_returns_empty_result_when_no_chunks(self, mock_db):
+        """チャンクが0件の場合はEmbedding生成せずに空結果を返すこと"""
+        _, mock_cursor, _ = mock_db
+        mock_cursor.fetchone.return_value = (0,)
+
+        with patch.object(vectorstore_module, "generate_embedding") as mock_gen:
+            result = vectorstore_module.search("テストクエリ")
+
+        mock_gen.assert_not_called()
+        assert result == {"documents": [[]], "metadatas": [[]], "distances": [[]]}
+
+    def test_returns_results_when_chunks_exist(self, mock_db):
+        """通常系: ヒットした行がdocuments/metadatas/distancesに正しく整形されること"""
+        _, mock_cursor, _ = mock_db
+        mock_cursor.fetchone.return_value = (3,)
+        mock_cursor.fetchall.return_value = [
+            ("内容1", "faq.txt", "faq", 0.1),
+            ("内容2", "manual.txt", "manual", 0.3),
+        ]
+
+        with patch.object(
+            vectorstore_module, "generate_embedding", return_value=[0.1] * 1536
+        ):
+            result = vectorstore_module.search("返品について", n_results=5)
+
+        assert result["documents"][0] == ["内容1", "内容2"]
+        assert result["metadatas"][0][0] == {
+            "document_name": "faq.txt",
+            "category": "faq",
+        }
+        assert result["distances"][0] == [0.1, 0.3]
+
+
+class TestDeleteDocument:
+    def test_deletes_existing_document(self, mock_db):
+        """該当チャンクがある場合はDELETEが実行され、削除件数が返ること"""
+        _, mock_cursor, _ = mock_db
+        mock_cursor.fetchone.return_value = (4,)
+
+        result = vectorstore_module.delete_document("doc-1")
+
+        assert result == 4
+        delete_calls = [
+            c for c in mock_cursor.execute.call_args_list if "DELETE" in c.args[0]
+        ]
+        assert len(delete_calls) == 1
+
+    def test_returns_zero_when_document_not_found(self, mock_db):
+        """該当チャンクがない場合はDELETEを実行せず0を返すこと"""
+        _, mock_cursor, _ = mock_db
+        mock_cursor.fetchone.return_value = (0,)
+
+        result = vectorstore_module.delete_document("not-exist")
+
+        assert result == 0
+        delete_calls = [
+            c for c in mock_cursor.execute.call_args_list if "DELETE" in c.args[0]
+        ]
+        assert len(delete_calls) == 0
+
+
+class TestGetDocumentStats:
+    def test_returns_empty_list(self, mock_db):
+        _, mock_cursor, _ = mock_db
+        mock_cursor.fetchall.return_value = []
+
+        result = vectorstore_module.get_document_stats()
+
+        assert result == []
+
+    def test_formats_rows_into_dicts(self, mock_db):
+        """uploaded_at が datetime の場合は isoformat() で文字列化されること"""
+        _, mock_cursor, _ = mock_db
+        fake_ts = MagicMock()
+        fake_ts.isoformat.return_value = "2026-07-26T00:00:00+00:00"
+        mock_cursor.fetchall.return_value = [
+            ("id1", "a.txt", "faq", fake_ts, 3),
+        ]
+
+        result = vectorstore_module.get_document_stats()
+
+        assert result == [
+            {
+                "id": "id1",
+                "name": "a.txt",
+                "category": "faq",
+                "uploaded_at": "2026-07-26T00:00:00+00:00",
+                "chunk_count": 3,
+            }
+        ]
+
+    def test_uploaded_at_empty_string_when_none(self, mock_db):
+        """uploaded_at が None の場合は空文字列になること"""
+        _, mock_cursor, _ = mock_db
+        mock_cursor.fetchall.return_value = [
+            ("id1", "a.txt", "faq", None, 0),
+        ]
+
+        result = vectorstore_module.get_document_stats()
+
+        assert result[0]["uploaded_at"] == ""
+
+
+class TestGetChunkCount:
+    def test_returns_count(self, mock_db):
+        _, mock_cursor, _ = mock_db
+        mock_cursor.fetchone.return_value = (7,)
+
+        result = vectorstore_module.get_chunk_count()
+
+        assert result == 7
+
+
+class TestMigrate:
+    def test_creates_extension_tables_and_index(self, mock_db):
+        """pgvector拡張・2テーブル・1インデックスの計4回executeされること"""
+        _, mock_cursor, _ = mock_db
+
+        vectorstore_module.migrate()
+
+        assert mock_cursor.execute.call_count == 4


### PR DESCRIPTION
## 概要

RAGパイプラインの中核である `app/services/embeddings.py`（Embedding生成）と `app/services/vectorstore.py`（pgvectorによる検索・追加・削除）にユニットテストを追加し、サービス層のテストカバレッジを引き上げる。

- `backend/tests/test_embeddings.py`（新規）
  - `get_client()` のシングルトンキャッシュ挙動
  - `generate_embeddings()` が `text-embedding-3-small` モデル・入力テキストで正しくAPIを呼び出し、レスポンスから embedding を取り出すこと
  - `generate_embedding()` が `generate_embeddings()` を単一要素リストで呼び出すこと
- `backend/tests/test_vectorstore.py`（新規）
  - `_get_database_url()` の `DATABASE_URL` 未設定時 `RuntimeError` / 設定時の値取得
  - `add_documents()` の空チャンク時の早期リターン、通常系でのINSERT呼び出し回数
  - `search()` のチャンク0件時のショートサーキット（Embedding生成をスキップ）、通常系での結果整形
  - `delete_document()` の削除件数・0件時（DELETE非実行）の挙動
  - `get_document_stats()` の行データ整形（`uploaded_at` が `None`/値ありの場合）
  - `get_chunk_count()` / `migrate()` の基本動作

外部依存（`psycopg2`, `openai`）は既存テスト（`test_documents.py`, `test_rag.py`）と同じ `sys.modules.setdefault()` パターンでモック化しており、実際のDB・OpenAI APIへの接続は発生しない。

## 背景

Issue #24 の通り、ルーター層（`routers/query.py`, `routers/documents.py`）は #17/PR #23 でテストが追加され、`services/rag.py` も #21/PR #22 でテストが追加された一方、`services/embeddings.py` と `services/vectorstore.py` はテストが存在せずカバレッジ 0% のまま残っていた。

Closes #24

## テスト計画

- [ ] `cd backend && pip install -r requirements.txt -r requirements-test.txt`
- [ ] `pytest tests/test_embeddings.py tests/test_vectorstore.py -v` で全テストがパスすること
- [ ] `pytest tests/ -v --cov=app --cov-report=term-missing` を実行し、`app/services/embeddings.py` と `app/services/vectorstore.py` のカバレッジが 0% から大幅に改善していること
- [ ] 既存テスト（`test_chunker.py`, `test_models.py`, `test_documents.py`, `test_documents_router.py`, `test_query_router.py`, `test_rag.py`）が引き続きすべてパスすること（他ファイルとの `sys.modules` モック共有による副作用がないことの確認）

## 補足

- 本PRはテスト追加のみで、アプリケーションコード（`app/`配下の非テストファイル）への変更は含まない。
- `.github/workflows/*.yml` は変更していない（既存の `ci.yml` の `pytest tests/ -v --cov=app ...` にこの2ファイルが自動的に含まれる）。
- なお、`backend/app/services/chunker.py` の巨大文一括分割バグ（`chunk_text()` がチャンクサイズを超える単一文を分割できない）は既に開いている PR #16 で修正提案済みのため、本PRのスコープからは意図的に除外している。


---
_Generated by [Claude Code](https://claude.ai/code/session_01JH8ntK1RwspoyutAE94UCu)_