### PR TITLE
docs: `CODE_OF_CONDUCT.md` を追加してコミュニティ行動規範を明文化

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,90 @@
+# Contributor Covenant Code of Conduct / コントリビューター行動規範
+
+## 私たちの誓い / Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+私たちメンバー・コントリビューター・リーダーは、年齢・体格・目に見える/見えない障害・
+民族・性的特徴・ジェンダー・経験のレベル・学歴・社会経済的地位・国籍・容姿・
+人種・宗教・性的指向にかかわらず、誰もが嫌がらせを受けずにコミュニティに参加できる
+ようにすることを誓います。
+
+## 私たちの基準 / Our Standards
+
+ポジティブな環境を作るために貢献する行動の例:
+
+- 他者への共感と親切心を示す
+- 異なる意見・視点・経験を尊重する
+- 建設的なフィードバックを行い、また受け入れる
+- 自分の誤りに責任を持ち、影響を受けた人々に謝罪し、経験から学ぶ
+- 個人だけでなくコミュニティ全体の利益を考える
+
+受け入れられない行動の例:
+
+- 性的な言葉遣いやイメージの使用、およびあらゆる形態の性的関心・アプローチ
+- 荒らし、侮辱的または軽蔑的なコメント、個人的・政治的攻撃
+- 公的または私的な嫌がらせ
+- 明示的な許可なく他人の個人情報（物理的住所・メールアドレス等）を公開する
+- 職業上の場において不適切と合理的にみなされうるその他の行為
+
+## 施行責任 / Enforcement Responsibilities
+
+コミュニティリーダーは、受け入れられる行動基準を明確にし施行する責任を負い、
+不適切・脅迫的・攻撃的・有害と判断した行動に対して、適切かつ公平な是正措置を
+講じます。
+
+## 適用範囲 / Scope
+
+この行動規範は、すべてのコミュニティスペース、およびコミュニティを公式に代表して
+公的スペースで発言・行動する場合に適用されます。
+
+## 施行 / Enforcement
+
+虐待的・嫌がらせ・その他受け入れられない行動の事例は、リポジトリオーナー
+(<moha.sayed0918@gmail.com>) に報告してください。すべての苦情は速やかかつ公正に
+レビュー・調査されます。
+
+コミュニティリーダーは、通報者のプライバシーとセキュリティを尊重する義務があります。
+
+## 施行ガイドライン / Enforcement Guidelines
+
+### 1. 訂正 / Correction
+
+**コミュニティへの影響**: 不適切な言葉遣い、または非専門的・不歓迎的とみなされる行動。
+
+**結果**: コミュニティリーダーからの非公開の書面による警告と、なぜその行動が
+不適切だったかの明確化。公開謝罪が求められる場合があります。
+
+### 2. 警告 / Warning
+
+**コミュニティへの影響**: 単一または一連の行動を通じた違反。
+
+**結果**: 継続的な行動に対する結果を伴う警告。指定された期間、関係者との
+やり取りが制限されます。この期間中の違反は一時的または永久的な追放につながる
+可能性があります。
+
+### 3. 一時的追放 / Temporary Ban
+
+**コミュニティへの影響**: 継続的な不適切行動を含む重大なコミュニティ基準違反。
+
+**結果**: 指定された期間、コミュニティとのあらゆる公的なやり取り・コミュニケーション
+からの一時的追放。
+
+### 4. 永久追放 / Permanent Ban
+
+**コミュニティへの影響**: 継続的な不適切行動・個人への嫌がらせ・グループへの
+攻撃や中傷を含むコミュニティ基準違反のパターンを示すこと。
+
+**結果**: コミュニティ内でのあらゆる公的なやり取りからの永久追放。
+
+## 帰属 / Attribution
+
+この行動規範は [Contributor Covenant][homepage] version 2.1 を基にしています:
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>
+
+[homepage]: https://www.contributor-covenant.org


### PR DESCRIPTION
## 変更概要

- ルート直下に `CODE_OF_CONDUCT.md` を新規追加
  - [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html) を基にした行動規範
  - 日本語 / 英語のバイリンガル表記
  - 施行連絡先: リポジトリオーナーメールアドレス

## 対応 Issue

Closes #26

## 動作確認手順

1. `CODE_OF_CONDUCT.md` を目視確認し、Markdown 構文が壊れていないこと
2. GitHub の Community Standards（`Insights > Community Standards`）で `Code of conduct` がチェックされる想定
3. 既存 CI (`.github/workflows/*.yml`) には変更なし → 挙動不変
4. `backend/` (Python/FastAPI) と `frontend/` のコードには変更なし

## リスク・注意

- 純粋な追加のみ。既存の RAG バックエンド・フロントエンド・CI ワークフローには影響しない。
- 別途オープンな Issue/PR（`#6`/`#7` エラーハンドリング、`#16` chunker fix、`#17`/`#18` ルーターテスト、`#24`/`#25` サービス層テスト）とは対象領域が異なるため独立にレビュー・マージ可能。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BYmqHxPYgdwDrm8q9Cseum)_