### PR TITLE
chore: Dependabot 設定を追加し依存関係の自動更新を有効化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,73 @@
+# Dependabot configuration
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # Python backend dependencies (FastAPI, openai, psycopg2, pytest, ...)
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(pip)"
+      include: "scope"
+
+  # Frontend Node.js dependencies (Next.js, React, TypeScript, ...)
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "chore(npm)"
+      include: "scope"
+
+  # GitHub Actions used in workflows (actions/checkout, setup-python, ...)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(actions)"
+      include: "scope"
+
+  # Backend Dockerfile base image
+  - package-ecosystem: "docker"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(docker)"
+      include: "scope"
+
+  # Frontend Dockerfile base image
+  - package-ecosystem: "docker"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(docker)"
+      include: "scope"


### PR DESCRIPTION
## 概要

`.github/dependabot.yml` を新規追加し、Dependabot による依存関係の週次自動更新を有効化する。本リポジトリは Python バックエンド・Next.js フロントエンド・GitHub Actions・Docker と 4 種類のエコシステムを併用しているが、これまで Dependabot 設定が存在せず、依存パッケージの脆弱性対応やアップグレードが完全に手動になっていた。

## 変更内容

- `.github/dependabot.yml` を新規追加
  - `pip`（`/backend`）: `requirements.txt` / `requirements-test.txt`
  - `npm`（`/frontend`）: `package.json`
  - `github-actions`（`/`）: `.github/workflows/*.yml` で使われるアクション
  - `docker`（`/backend`, `/frontend`）: `Dockerfile` ベースイメージ
- 各エコシステム共通の設定
  - `schedule.interval: weekly` / `day: monday`（PR 洪水の抑制）
  - `open-pull-requests-limit: 5`
  - `labels`: `dependencies` に加え、エコシステム別ラベル（`python` / `javascript` / `github-actions` / `docker`）
  - `commit-message.prefix`: `chore(pip)` / `chore(npm)` / `chore(actions)` / `chore(docker)`

アプリケーションコード・既存 CI ワークフローには一切変更を加えていない。Dependabot が今後作成する PR は既存の `ci.yml`（pytest + カバレッジ + bandit + pip-audit）によって自動的に検証される。

Closes #28

## 動作確認手順

- [ ] マージ後、リポジトリの Settings → Code security and analysis → Dependabot version updates が有効になっていることを確認
- [ ] Insights → Dependency graph → Dependabot タブで `.github/dependabot.yml` が正しく解釈され、5 つのエコシステム（pip x1, npm x1, github-actions x1, docker x2）が登録されていることを確認
- [ ] 次の月曜日以降、更新対象がある場合は Dependabot が自動的に PR を作成すること（あるいは手動で `Check for updates` を実行して即時確認）
- [ ] 作成された PR に `dependencies` ラベルと該当エコシステムのラベルが付与されていること
- [ ] `.github/workflows/ci.yml` の CI が新しい PR で正常に完走すること

---
_Generated by [Claude Code](https://claude.ai/code/session_01WENwnBzXhc1HN4NdbprXyE)_