### PR TITLE
test(embeddings): OpenAI SDK モック済みユニットテストを追加

### DIFF
--- a/backend/tests/test_embeddings.py
+++ b/backend/tests/test_embeddings.py
@@ -1,0 +1,108 @@
+"""app.services.embeddings のユニットテスト。
+
+OpenAI SDK 呼び出しは monkeypatch でスタブ化し、
+外部 API に依存しないローカル実行のみで完結させる。
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.services import embeddings
+
+
+@pytest.fixture(autouse=True)
+def _reset_client_singleton():
+    """テスト間で `_client` シングルトンを持ち越さない。
+
+    `get_client` が返す OpenAI クライアントは module 変数に保持されるため、
+    fixture の scope=function として各テスト前後で必ずリセットする。
+    """
+    embeddings._client = None
+    yield
+    embeddings._client = None
+
+
+class _FakeUsage:
+    def __init__(self, total_tokens: int) -> None:
+        self.total_tokens = total_tokens
+
+
+class _FakeEmbeddings:
+    """`OpenAI.embeddings.create` を差し替えるためのフェイク。
+
+    渡された `input` のサイズに合わせて data を返し、
+    入力を最後の呼び出し引数として `last_call` に記録する。
+    """
+
+    def __init__(self) -> None:
+        self.last_call: dict | None = None
+
+    def create(self, *, model: str, input: list[str]):
+        self.last_call = {"model": model, "input": input}
+        data = [SimpleNamespace(embedding=[float(i), float(i) + 0.5]) for i, _ in enumerate(input)]
+        return SimpleNamespace(data=data, usage=_FakeUsage(total_tokens=len(input) * 3))
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.embeddings = _FakeEmbeddings()
+
+
+def test_get_client_is_singleton(monkeypatch):
+    """`get_client` は一度作成した OpenAI クライアントを再利用する。"""
+    created: list[_FakeClient] = []
+
+    def _factory():
+        client = _FakeClient()
+        created.append(client)
+        return client
+
+    monkeypatch.setattr(embeddings, "OpenAI", _factory)
+    first = embeddings.get_client()
+    second = embeddings.get_client()
+
+    assert first is second
+    assert len(created) == 1
+
+
+def test_generate_embeddings_returns_vectors(monkeypatch):
+    """`generate_embeddings` は SDK レスポンスから embedding 配列だけを抽出する。"""
+    fake_client = _FakeClient()
+    monkeypatch.setattr(embeddings, "OpenAI", lambda: fake_client)
+
+    vectors = embeddings.generate_embeddings(["こんにちは", "テスト", "hello"])
+
+    assert vectors == [[0.0, 0.5], [1.0, 1.5], [2.0, 2.5]]
+    assert fake_client.embeddings.last_call == {
+        "model": "text-embedding-3-small",
+        "input": ["こんにちは", "テスト", "hello"],
+    }
+
+
+def test_generate_embeddings_empty_input(monkeypatch):
+    """入力が空のときは空配列を返す（SDK 呼び出しは行われる）。"""
+    fake_client = _FakeClient()
+    monkeypatch.setattr(embeddings, "OpenAI", lambda: fake_client)
+
+    vectors = embeddings.generate_embeddings([])
+
+    assert vectors == []
+    assert fake_client.embeddings.last_call == {
+        "model": "text-embedding-3-small",
+        "input": [],
+    }
+
+
+def test_generate_embedding_single(monkeypatch):
+    """`generate_embedding` は `generate_embeddings` の 1 件版として最初の要素を返す。"""
+    fake_client = _FakeClient()
+    monkeypatch.setattr(embeddings, "OpenAI", lambda: fake_client)
+
+    vector = embeddings.generate_embedding("単一テキスト")
+
+    assert vector == [0.0, 0.5]
+    assert fake_client.embeddings.last_call == {
+        "model": "text-embedding-3-small",
+        "input": ["単一テキスト"],
+    }


### PR DESCRIPTION
## 変更概要

- `backend/app/services/embeddings.py` のユニットテストを新規追加。OpenAI SDK は `monkeypatch` で差し替え、外部 API に依存せずローカル実行のみで完結する。

## 対応 Issue

Refs #24（本 PR では `embeddings.py` を先行。`vectorstore.py` は Postgres 依存のため別 PR で扱う想定）

## 変更内容の詳細

`backend/tests/test_embeddings.py` を新規作成。次の 4 テストを含む：

- `test_get_client_is_singleton` — `get_client` が一度作成した OpenAI クライアントを再利用する
- `test_generate_embeddings_returns_vectors` — SDK レスポンスの `.data[i].embedding` を配列で返し、`model` / `input` を SDK に正しく渡す
- `test_generate_embeddings_empty_input` — 入力が空でも空配列を返し、SDK 呼び出しは行う
- `test_generate_embedding_single` — 単一版が複数版の先頭要素を返す

## 動作確認手順

1. `cd backend && pip install -r requirements.txt -r requirements-test.txt`
2. `python -m pytest tests/test_embeddings.py -v` — 4 テスト全てグリーン

## リスク・注意点

- テストは `openai` パッケージのインポート後に `embeddings.OpenAI` を monkeypatch で差し替える。外部通信は一切発生しない
- `embeddings._client` はモジュールグローバルのため、`autouse` fixture で各テスト前後にリセット
- **既知の事前不具合**: `tests/test_chunker.py` の `test_custom_chunk_size` / `test_env_var_chunk_size` は `main` で既に失敗している（`chunk_text` が sentence terminator 無しの長文を hard-split しないため）。本 PR の変更とは無関係。別 Issue での対応を推奨

---
_Generated by [Claude Code](https://claude.ai/code/session_01Achapz3fsaVGZjAZE5R1Aw)_