### PR TITLE
ci: pip キャッシュを追加して依存関係インストールを高速化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-test.txt
 
       - name: Install dependencies
         working-directory: backend
@@ -50,6 +54,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-test.txt
 
       - name: Install security tools
         working-directory: backend


### PR DESCRIPTION
## 変更概要

- `.github/workflows/ci.yml` の `test` / `security` 両ジョブの `actions/setup-python@v5` に `cache: 'pip'` および `cache-dependency-path` を追加
- `cache-dependency-path` には `backend/requirements.txt` と `backend/requirements-test.txt` の 2 ファイルを列挙し、これらのハッシュを鍵に `~/.cache/pip` を自動リストア
- インストールステップ (`run`) や実行コマンドは変更しないため、キャッシュヒット時もミス時も挙動は同一

## 対応 Issue

Closes #59

## 影響範囲

- [ ] `backend/`（FastAPI / retriever / LLM 連携）
- [ ] `frontend/`（React アプリ）
- [ ] `sample_data/`（サンプルドキュメント）
- [ ] `docker-compose.yml`
- [x] ドキュメント / CI 設定のみ
- [ ] その他:

## 動作確認手順

1. ローカルで YAML 構文を検証: `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → 例外が出ないこと
2. `actions/setup-python@v5` の `with` ブロックに `cache: pip` と `cache-dependency-path` が 2 ジョブ両方に付与されていることを確認
3. マージ後、次回以降の CI 実行ログで `Setup Python` ステップに `Cache restored successfully` / `Cache saved successfully` が出力されることを確認 (初回はキャッシュミス、2 回目以降でヒット)
4. 依存が変化しない PR で、`pip install -r requirements.txt` のインストール時間が短縮されていることを確認

## チェックリスト

- [x] `pytest` がローカルでパスすること（`backend/tests/`） — 本 PR はコード変更なし
- [x] `bandit -r app/ -ll -ii` で新規高/中リスクが出ていない — 本 PR はコード変更なし
- [x] `pip-audit --requirement requirements.txt` で新規脆弱性が出ていない — 本 PR は依存変更なし
- [x] 環境変数追加時は `.env.example`（もしできるなら backend/README）を更新済み — 環境変数の追加なし

## 補足

- `actions/setup-python@v5` の pip キャッシュ機能はネイティブサポートで、追加 action の導入は不要
- キャッシュキーは `cache-dependency-path` に列挙したファイルの内容ハッシュに基づくため、`requirements*.txt` を更新した PR では自動的に新規キャッシュが作成される
- キャッシュヒットに失敗しても pip インストールは通常通り実行されるため、リグレッションリスクは低い


---
_Generated by [Claude Code](https://claude.ai/code/session_01XSfXMiHzvrKAGaL5dphK1B)_